### PR TITLE
[fix]frontend-vue3：formタグ削除

### DIFF
--- a/frontend-vue3/src/components/Form.vue
+++ b/frontend-vue3/src/components/Form.vue
@@ -1,7 +1,5 @@
 <template>
-  <form :id="formId">
-    <input :id="inputId" v-model="inputValue" type="text" />
-  </form>
+  <input :id="inputId" v-model="inputValue" type="text" />
 </template>
 
 <script lang="ts">
@@ -14,10 +12,6 @@ export default defineComponent({
     modelValue: {
       type: String,
       default: "",
-    },
-    formId: {
-      type: String,
-      default: "frm-post",
     },
     inputId: {
       type: String,


### PR DESCRIPTION
# 概要
formタグで囲まれているとclick時にpostが走るのでタグを削除しました。